### PR TITLE
Fix arrays comparison

### DIFF
--- a/UnitTestFramework.brs
+++ b/UnitTestFramework.brs
@@ -84,7 +84,7 @@ function BaseTestSuite()
     this.eqValues                       = BTS__EqValues
     this.eqAssocArrays                  = BTS__EqAssocArray
     this.eqArrays                       = BTS__EqArray
-    this.baseComparator                 = BTS__BaseComparator 
+    this.compare                        = BTS__BaseCompare
 
     return this
 End Function
@@ -591,8 +591,8 @@ End Function
 '
 ' @return True if values are equal or False in other case.
 '----------------------------------------------------------------
-Function BTS__EqValues(Value1 as dynamic, Value2 as dynamic, comparator = m.baseComparator as Function) as Boolean
-    return comparator(value1, value2)
+Function BTS__EqValues(Value1 as dynamic, Value2 as dynamic) as Boolean
+    return m.compare(value1, value2)
 End Function
 
 '----------------------------------------------------------------
@@ -602,7 +602,7 @@ End Function
 ' @param Value2 (dynamic) A second item to compare.
 '
 ' @return True if values are equal or False in other case.
-function BTS__BaseComparator(value1 as Dynamic, value2 as Dynamic) as Boolean
+function BTS__BaseCompare(value1 as Dynamic, value2 as Dynamic) as Boolean
     value1Type = type(value1)
     value2Type = type(value2)
     

--- a/samples/SimpleTestApp/dev/source/main.brs
+++ b/samples/SimpleTestApp/dev/source/main.brs
@@ -6,7 +6,7 @@ sub RunUserInterface(args)
         Runner = TestRunner()
         Runner.logger.SetVerbosity(2)
         Runner.logger.SetEcho(true)
-        Runner.SetFailFast(true)
+        Runner.SetFailFast(false)
         Runner.Run()
     end if
 end sub

--- a/samples/SimpleTestApp/dev/source/tests/Test__Main.brs
+++ b/samples/SimpleTestApp/dev/source/tests/Test__Main.brs
@@ -36,6 +36,8 @@ Function TestSuite__Main() as Object
     this.addTest("CheckStreamFormatType", TestCase__Main_CheckStreamFormatType)
     this.addTest("TestAddPrefixFunction__Failed", TestCase__Main_TestAddPrefixFunction__Failed)
     this.addTest("TestAddPrefixFunction__Passed", TestCase__Main_TestAddPrefixFunction__Passed)
+    this.addTest("TestComparesAssociativeArrays", TestCase__Main_TestComparesAssociativeArrays)
+    this.addTest("TestComparesArrays", TestCase__Main_TestComparesArrays)
 
     return this
 End Function
@@ -119,6 +121,28 @@ Function TestCase__Main_TestAddPrefixFunction__Failed() as String
     result = AddPrefixToAAItems(inputObject)
 
     return m.assertNotInvalid(result, "Input data is invalid. All values should be strings.")
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical associative arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesAssociativeArrays() as String
+    array = { key1: "key1", key2: "key2" }
+
+    return m.assertEqual(array, array)
+End Function
+
+'----------------------------------------------------------------
+' Compares two identical arrays
+'
+' @return An empty string if test is success or error message if not.
+'----------------------------------------------------------------
+Function TestCase__Main_TestComparesArrays() as String
+    array = ["one", "two"]
+
+    return m.assertEqual(array, array)
 End Function
 
 '----------------------------------------------------------------


### PR DESCRIPTION
comparator was trying to use methods of `BaseTestSuite` which resulted in
```
609:      if (value1Type = "roList" or value1Type = "roArray") and (value2Type = "roList" or value2Type = "roArray")
610:*         return m.eqArrays(value1, value2)
611:      else if value1Type = "roAssociativeArray" and value2Type = "roAssociativeArray"
612:          return m.eqAssocArrays(value1, value2)

Member function not found in BrightScript Component or interface. (runtime error &hf4) in pkg:/source/testFramework/UnitTestFramework.brs(610)
```
The same for associative arrays.

Here I changed baseComparator to `compare` method, which solves this issue. Of course it can also be done differently, but I think this is the easiest fix, and not creating any new objects will help with readability.