### PR TITLE
Brightscript v3 compatibility using Type()

### DIFF
--- a/UnitTestFramework.brs
+++ b/UnitTestFramework.brs
@@ -2673,7 +2673,7 @@ function TF_Utils__BaseComparator(value1 as Dynamic, value2 as Dynamic) as Boole
         return TF_Utils__EqArray(value1, value2)
     else if value1Type = "roAssociativeArray" and value2Type = "roAssociativeArray"
         return TF_Utils__EqAssocArray(value1, value2)
-    else if Type(box(value1)) = Type(box(value2))
+    else if Type(Box(value1), 3) = Type(Box(value2), 3)
         return value1 = value2
     else
         return false


### PR DESCRIPTION
These changes fix casting values into object versions using type() function.

Based on https://sdkdocs.roku.com/display/sdkdoc/Expressions%2C+Variables%2C+and+Types:
`BrightScript 3 has a few changes that affect types. These are hidden from the programmer, unless the new optional "3" parameter is passed to "type()". Without this parameter, "type()" will return a BrightScript 2.1 compatible type.`

![image](https://user-images.githubusercontent.com/1011926/52639994-d4866500-2ed5-11e9-9ad9-0d915d244f8f.png)
![image](https://user-images.githubusercontent.com/1011926/52640006-d94b1900-2ed5-11e9-8efc-41ccc8f695b8.png)

Brightscript v3 has been introduced with Roku OS v4.1 (21.12.2011) so it's totally safe.