### PR TITLE
Running specific tests in the non-node mode

### DIFF
--- a/UnitTestFramework.brs
+++ b/UnitTestFramework.brs
@@ -1720,45 +1720,35 @@ end function
 ' Set testsDirectory property.
 ' ----------------------------------------------------------------
 sub TestRunner__SetTestsDirectory(testsDirectory as String)
-    if testsDirectory <> invalid
-        m.testsDirectory = testsDirectory
-    end if
+    m.testsDirectory = testsDirectory
 end sub
 
 ' ----------------------------------------------------------------
 ' Set setTestFilePrefix property.
 ' ----------------------------------------------------------------
 sub TestRunner__SetTestFilePrefix(testFilePrefix as String)
-    if testFilePrefix <> invalid
-        m.testFilePrefix = setTestFilePrefix
-    end if
+    m.testFilePrefix = setTestFilePrefix
 end sub
 
 ' ----------------------------------------------------------------
 ' Set testSuitePrefix property.
 ' ----------------------------------------------------------------
 sub TestRunner__SetTestSuitePrefix(testSuitePrefix as String)
-    if testSuitePrefix <> invalid
-        m.testSuitePrefix = testSuitePrefix
-    end if
+    m.testSuitePrefix = testSuitePrefix
 end sub
 
 ' ----------------------------------------------------------------
 ' Set testSuiteName property.
 ' ----------------------------------------------------------------
 sub TestRunner__SetTestSuiteName(testSuiteName as String)
-    if testSuiteName <> invalid
-        m.testSuiteName = testSuiteName
-    end if
+    m.testSuiteName = testSuiteName
 end sub
 
 ' ----------------------------------------------------------------
 ' Set testCaseName property.
 ' ----------------------------------------------------------------
 sub TestRunner__SetTestCaseName(testCaseName as String)
-    if testCaseName <> invalid
-        m.testCaseName = testCaseName
-    end if
+    m.testCaseName = testCaseName
 end sub
 
 ' ----------------------------------------------------------------

--- a/UnitTestFramework.brs
+++ b/UnitTestFramework.brs
@@ -1690,7 +1690,8 @@ function TestRunner__Run(statObj = m.Logger.CreateTotalStatistic() as Object, te
                         m.Logger.AppendSuiteStatistic(totalStatObj, suiteStatObj)
                     end for
                 else
-                    tmp = testNode.callFunc("TestFramework__RunNodeTests", [totalStatObj, testSuiteNamesList])
+                    params = [totalStatObj, testSuiteNamesList, m.testSuiteName, m.testCaseName]
+                    tmp = testNode.callFunc("TestFramework__RunNodeTests", params)
                     if tmp <> invalid then
                         totalStatObj = tmp
                     end if
@@ -2192,8 +2193,13 @@ end function
 function TestFramework__RunNodeTests(params as Object) as Object
     statObj = params[0]
     testSuiteNamesList = params[1]
+    testSuiteName = params[2]
+    testCaseName = params[3]
 
     Runner = TestRunner()
+    Runner.SetTestSuiteName(testSuiteName)
+    Runner.SetTestCaseName(testCaseName)
+
     return Runner.Run(statObj, testSuiteNamesList)
 end function
 function UTF_skip(msg = "")

--- a/UnitTestFramework.brs
+++ b/UnitTestFramework.brs
@@ -1727,7 +1727,7 @@ end sub
 ' Set setTestFilePrefix property.
 ' ----------------------------------------------------------------
 sub TestRunner__SetTestFilePrefix(testFilePrefix as String)
-    m.testFilePrefix = setTestFilePrefix
+    m.testFilePrefix = testFilePrefix
 end sub
 
 ' ----------------------------------------------------------------


### PR DESCRIPTION
Currently setting testSuiteName and testCaseName doesn't work in non-node mode (TestFramework__RunNodeTests is creating its own TestRunner and data from its "parent" isn't passed).
I also fixed the TestRunner__SetTestFilePrefix function - it doesn't work without my fix.
By the way, I removed unnecessary checks if string arguments aren't Invalid (they are unnecessary because passing Invalid as a string-declared argument breaks the app)